### PR TITLE
GTPv2: fix minimum IE length for all flags IEs

### DIFF
--- a/priv/ie_gen_v2.erl
+++ b/priv/ie_gen_v2.erl
@@ -118,7 +118,7 @@ raw_ies() ->
      {76, "v2 MSISDN",
       [{"MSISDN", 0, {type, tbcd}}]},
      {77, "v2 Indication",
-      [{"Flags", 0,
+      [{"Flags", 16,
 	{flags,	['DAF', 'DTF', 'HI', 'DFI', 'OI', 'ISRSI', 'ISRAI', 'SGWCI',
 		 'SQCI', 'UIMSI', 'CFSI', 'CRSI', 'P', 'PT', 'SI', 'MSV',
 		 'RetLoc', 'PBIC', 'SRNI', 'S6AF', 'S4AF', 'MBMDT', 'ISRAU', 'CCRSI',

--- a/src/gtp_packet.erl
+++ b/src/gtp_packet.erl
@@ -4106,22 +4106,22 @@ encode_v2_element(#v2_msisdn{
 encode_v2_element(#v2_indication{
 		     instance = Instance,
 		     flags = M_flags}) ->
-    encode_v2_element(77, Instance, <<(encode_min_int(0, encode_flags(M_flags, ['SGWCI','ISRAI','ISRSI','OI','DFI',
-                                          'HI','DTF','DAF','MSV','SI','PT',
-                                          'P','CRSI','CFSI','UIMSI','SQCI',
-                                          'CCRSI','ISRAU','MBMDT','S4AF',
-                                          'S6AF','SRNI','PBIC','RetLoc',
-                                          'CPSR','CLII','CSFBI','PPSI',
-                                          'PPON/PPEI','PPOF','ARRL','CPRAI',
-                                          'AOPI','AOSI','PCRI','PSCI','BDWI',
-                                          'DTCI','UASI','NSI','WPMSI',
-                                          'UNACCSI','PNSI','S11TF','PMTSMI',
-                                          'CPOPCI','EPCOSI','ROAAI','TSPCMI',
-                                          'ENBCRSI','LTEMPI','LTEMUI',
-                                          'EEVRSI','5GSIWK','REPREFI',
-                                          '5GSNN26','ETHPDN','5SRHOI',
-                                          '5GCNRI','5GCNRS','N5GNMI','_','_',
-                                          '_']), little))/binary>>);
+    encode_v2_element(77, Instance, <<(encode_min_int(16, encode_flags(M_flags, ['SGWCI','ISRAI','ISRSI','OI','DFI',
+                                           'HI','DTF','DAF','MSV','SI','PT',
+                                           'P','CRSI','CFSI','UIMSI','SQCI',
+                                           'CCRSI','ISRAU','MBMDT','S4AF',
+                                           'S6AF','SRNI','PBIC','RetLoc',
+                                           'CPSR','CLII','CSFBI','PPSI',
+                                           'PPON/PPEI','PPOF','ARRL','CPRAI',
+                                           'AOPI','AOSI','PCRI','PSCI','BDWI',
+                                           'DTCI','UASI','NSI','WPMSI',
+                                           'UNACCSI','PNSI','S11TF','PMTSMI',
+                                           'CPOPCI','EPCOSI','ROAAI','TSPCMI',
+                                           'ENBCRSI','LTEMPI','LTEMUI',
+                                           'EEVRSI','5GSIWK','REPREFI',
+                                           '5GSNN26','ETHPDN','5SRHOI',
+                                           '5GCNRI','5GCNRS','N5GNMI','_','_',
+                                           '_']), little))/binary>>);
 
 encode_v2_element(#v2_protocol_configuration_options{
 		     instance = Instance,

--- a/test/gtp_SUITE.erl
+++ b/test/gtp_SUITE.erl
@@ -376,12 +376,13 @@ partial_encode(_Config) ->
     ok.
 
 flags_enc_dec(_Config) ->
-    Bin1 = <<72,1,0,13,0,0,0,0,0,0,0,0,77,0,1,0,128>>,
+    %% test minimum length of Indication IE
+    Bin1 = <<72,1,0,14,0,0,0,0,0,0,0,0,77,0,2,0,128,0>>,
     Msg1 = #gtp{version = v2,type = echo_request,tei = 0,seq_no = 0,
 	       n_pdu = undefined,ext_hdr = [],
 	       ie = #{{v2_indication,0} =>
 			  #v2_indication{instance = 0,flags = ['DAF']}}},
-    ?match(<<72,1,0,13,0,0,0,0,0,0,0,0,77,0,1,0,128>>, gtp_packet:encode(Msg1)),
+    ?match(<<72,1,0,14,0,0,0,0,0,0,0,0,77,0,2,0,128,0>>, gtp_packet:encode(Msg1)),
     ?match(#gtp{version = v2,type = echo_request,tei = 0,seq_no = 0,
 		n_pdu = undefined,ext_hdr = [],
 		ie = #{{v2_indication,0} :=


### PR DESCRIPTION
This is a follow up to 45cd42a8f. There the groundwork was layed, but
the actuall application to the Indication IE was missing.