### PR TITLE
de/encode location information into records

### DIFF
--- a/include/gtp_packet.hrl
+++ b/include/gtp_packet.hrl
@@ -45,23 +45,23 @@
 	  ie		:: [term()] | map() | binary()
 	 }).
 
+-record(cgi, {plmn, lac, ci}).
+-record(sai, {plmn, lac, sac}).
+-record(rai, {plmn, lac, rac}).
+-record(tai, {plmn, tac}).
+-record(ecgi, {plmn, eci}).
+-record(lai, {plmn, lac}).
+-record(macro_enb, {plmn, id}).
+-record(ext_macro_enb, {plmn, id}).
+
 -record(routeing_area_identity, {
 	  instance = 0,
-	  mcc,
-	  mnc,
-	  lac = 0,
-	  rac = 0
+	  identity
 	 }).
 
 -record(user_location_information, {
 	  instance = 0,
-	  type,
-	  mcc,
-	  mnc,
-	  lac = 0,
-	  ci = 0,
-	  sac = 0,
-	  rac = 0
+	  location
 	 }).
 
 -record(data_record_packet, {

--- a/include/gtp_packet.hrl
+++ b/include/gtp_packet.hrl
@@ -45,14 +45,14 @@
 	  ie		:: [term()] | map() | binary()
 	 }).
 
--record(cgi, {plmn, lac, ci}).
--record(sai, {plmn, lac, sac}).
--record(rai, {plmn, lac, rac}).
--record(tai, {plmn, tac}).
--record(ecgi, {plmn, eci}).
--record(lai, {plmn, lac}).
--record(macro_enb, {plmn, id}).
--record(ext_macro_enb, {plmn, id}).
+-record(cgi, {plmn_id, lac, ci}).
+-record(sai, {plmn_id, lac, sac}).
+-record(rai, {plmn_id, lac, rac}).
+-record(tai, {plmn_id, tac}).
+-record(ecgi, {plmn_id, eci}).
+-record(lai, {plmn_id, lac}).
+-record(macro_enb, {plmn_id, id}).
+-record(ext_macro_enb, {plmn_id, id}).
 
 -record(routeing_area_identity, {
 	  instance = 0,
@@ -849,8 +849,7 @@
 
 -record(v2_serving_network, {
 	  instance = 0,
-	  mcc = <<"001">>,
-	  mnc = <<"001">>
+	  plmn_id = {<<"001">>, <<"001">>}
 }).
 
 -record(v2_eps_bearer_level_traffic_flow_template, {
@@ -872,8 +871,7 @@
 
 -record(v2_global_cn_id, {
 	  instance = 0,
-	  mcc = <<"001">>,
-	  mnc = <<"001">>,
+	  plmn_id = {<<"001">>, <<"001">>},
 	  value = <<>>
 }).
 
@@ -912,8 +910,7 @@
 
 -record(v2_trace_information, {
 	  instance = 0,
-	  mcc = <<"001">>,
-	  mnc = <<"001">>,
+	  plmn_id = {<<"001">>, <<"001">>},
 	  trace_id = 0,
 	  triggering_events = <<0,0,0,0,0,0,0,0,0>>,
 	  list_of_ne_types = 0,
@@ -998,8 +995,7 @@
 
 -record(v2_trace_reference, {
 	  instance = 0,
-	  mcc = <<"001">>,
-	  mnc = <<"001">>,
+	  plmn_id = {<<"001">>, <<"001">>},
 	  id = 0
 }).
 
@@ -1011,8 +1007,7 @@
 
 -record(v2_guti, {
 	  instance = 0,
-	  mcc = <<"001">>,
-	  mnc = <<"001">>,
+	  plmn_id = {<<"001">>, <<"001">>},
 	  group_id = 0,
 	  code = 0,
 	  m_tmsi = <<>>
@@ -1149,8 +1144,7 @@
 
 -record(v2_user_csg_information, {
 	  instance = 0,
-	  mcc = <<"001">>,
-	  mnc = <<"001">>,
+	  plmn_id = {<<"001">>, <<"001">>},
 	  csg_id = <<0,0,0,0:3>>,
 	  access_mode = 0,
 	  lcsg = false,
@@ -1446,8 +1440,7 @@
 
 -record(v2_extended_trace_information, {
 	  instance = 0,
-	  mcc = <<"001">>,
-	  mnc = <<"001">>,
+	  plmn_id = {<<"001">>, <<"001">>},
 	  trace_id = 0,
 	  triggering_events = <<>>,
 	  list_of_ne_types = <<>>,

--- a/priv/ie_gen_v2.erl
+++ b/priv/ie_gen_v2.erl
@@ -160,7 +160,7 @@ raw_ies() ->
       [{"RAT Type", 8, integer},
        {'_', 0}]},
      {83, "v2 Serving Network",
-      [{"MCCMNC", mccmnc},
+      [{"PLMN", mccmnc},
        {'_', 0}]},
      {84, "v2 EPS Bearer Level Traffic Flow Template",
       [{"Value", 0, binary}]},
@@ -171,7 +171,7 @@ raw_ies() ->
      {88, "v2 TMSI",
       [{"Value", 32, integer}]},
      {89, "v2 Global CN-Id",
-      [{"MCCMNC", mccmnc},
+      [{"PLMN", mccmnc},
        {"Value", 0, binary}]},
      {90, "v2 S103 PDN Data Forwarding Info",
       [{"HSGW Address", 8, length_binary},
@@ -192,7 +192,7 @@ raw_ies() ->
       [{"Value", 2, bytes},
        {'_', 0}]},
      {96, "v2 Trace Information",
-      [{"MCCMNC", mccmnc},
+      [{"PLMN", mccmnc},
        {"Trace ID", 32, integer},
        {"Triggering Events", 9, bytes},
        {"List of NE Types", 16, integer},
@@ -240,13 +240,13 @@ raw_ies() ->
        {"DST", 2, integer},
        {'_', 0}]},
      {115, "v2 Trace Reference",
-      [{"MCCMNC", mccmnc},
+      [{"PLMN", mccmnc},
        {"Id", 24, integer}]},
      {116, "v2 Complete Request Message",
       [{"Type", 8, integer},
        {"Message", 0, binary}]},
      {117, "v2 GUTI",
-      [{"MCCMNC", mccmnc},
+      [{"PLMN", mccmnc},
        {"Group Id", 16, integer},
        {"Code", 24, integer},
        {"M-TMSI", 0, binary}]},
@@ -327,7 +327,7 @@ raw_ies() ->
      {144, "v2 RFSP Index",
       [{"Value", 16, integer}]},
      {145, "v2 User CSG Information",
-      [{"MCCMNC", mccmnc},
+      [{"PLMN", mccmnc},
        {'_', 5},
        {"CSG Id", 27, bits},
        {"Access mode", 2, integer},
@@ -494,7 +494,7 @@ raw_ies() ->
        {"APN Rate Control Status validity Time", 64, integer},
        {'_', 0}]},
      {205, "v2 Extended Trace Information",
-      [{"MCCMNC", mccmnc},
+      [{"PLMN", mccmnc},
        {"Trace ID", 32, integer},
        {"Triggering Events", 8, length_binary},
        {"List of NE Types", 8, length_binary},
@@ -649,7 +649,7 @@ ies() ->
 gen_record_def(#field{type = '_'}) ->
     [];
 gen_record_def(#field{spec = mccmnc}) ->
-    ["mcc = <<\"001\">>", "mnc = <<\"001\">>"];
+    ["plmn_id = {<<\"001\">>, <<\"001\">>}"];
 gen_record_def(#field{name = Name, optional = true}) ->
     [to_string(Name)];
 gen_record_def(#field{name = Name, type = flags}) ->
@@ -710,8 +710,7 @@ gen_decoder_header_match(#field{name = Name, len = Size, type = Type}) ->
 gen_decoder_record_assign(#field{type = '_'}) ->
     [];
 gen_decoder_record_assign(#field{name = Name, spec = mccmnc}) ->
-    [io_lib:format("mcc = decode_mcc(M_~s)", [Name]),
-     io_lib:format("mnc = decode_mnc(M_~s)", [Name])];
+    [io_lib:format("plmn_id = {decode_mcc(M_~s), decode_mnc(M_~s)}", [Name, Name])];
 gen_decoder_record_assign(#field{name = Name, type = flags, spec = Flags}) ->
     [io_lib:format("~s = decode_flags(M_~s, ~p)",
 		   [Name, Name, Flags])];
@@ -735,7 +734,7 @@ gen_decoder_record_assign(#field{name = Name}) ->
 gen_encoder_record_assign(#field{type = '_'}) ->
     [];
 gen_encoder_record_assign(#field{spec = mccmnc}) ->
-    ["mcc = M_mcc", "mnc = M_mnc"];
+    ["plmn_id = {M_mcc, M_mnc}"];
 gen_encoder_record_assign(#field{name = Name, type = undefined}) ->
     [io_lib:format("~s = undefined", [Name])];
 gen_encoder_record_assign(#field{name = Name}) ->

--- a/test/gtp_SUITE.erl
+++ b/test/gtp_SUITE.erl
@@ -206,7 +206,7 @@ v2_pco_vendor_ext() ->
 	 #v2_rat_type{rat_type = 6},
 	 #v2_selection_mode{mode = 0},
 	 #v2_serving_network{
-	    mcc = <<"302">>, mnc = <<"610">>},
+	    plmn_id = {<<"302">>, <<"610">>}},
 	 #v2_ue_time_zone{timezone = 138,dst = 0},
 	 #v2_user_location_information{
 	    cgi = undefined,

--- a/test/property_test/gtplib_prop.erl
+++ b/test/property_test/gtplib_prop.erl
@@ -747,21 +747,21 @@ gen_routeing_area_identity() ->
 
 gen_v1_cgi() ->
     #cgi{
-       plmn = plmn(),
+       plmn_id = plmn(),
        lac = uint16(),
        ci = uint16()
       }.
 
 gen_v1_sai() ->
     #sai{
-       plmn = plmn(),
+       plmn_id = plmn(),
        lac = uint16(),
        sac = uint16()
       }.
 
 gen_v1_rai() ->
     #rai{
-       plmn = plmn(),
+       plmn_id = plmn(),
        lac = uint16(),
        rac = ?LET(L, uint8(), (L bsl 8) bor 16#ff)
       }.
@@ -1840,52 +1840,52 @@ gen_v2_traffic_aggregation_description() ->
 
 gen_v2_cgi() ->
     #cgi{
-       plmn = plmn(),
+       plmn_id = plmn(),
        lac = uint16(),
        ci = uint16()
       }.
 
 gen_v2_sai() ->
     #sai{
-       plmn = plmn(),
+       plmn_id = plmn(),
        lac = uint16(),
        sac = uint16()
       }.
 
 gen_v2_rai() ->
     #rai{
-       plmn = plmn(),
+       plmn_id = plmn(),
        lac = uint16(),
        rac = uint16()
       }.
 
 gen_v2_tai() ->
     #tai{
-       plmn = plmn(),
+       plmn_id = plmn(),
        tac = uint16()
       }.
 
 gen_v2_ecgi() ->
     #ecgi{
-       plmn = plmn(),
+       plmn_id = plmn(),
        eci = uint(28)
       }.
 
 gen_v2_lai() ->
     #lai{
-       plmn = plmn(),
+       plmn_id = plmn(),
        lac = uint16()
       }.
 
 gen_v2_macro_enb() ->
     #macro_enb{
-       plmn = plmn(),
+       plmn_id = plmn(),
        id = uint(20)
       }.
 
 gen_v2_ext_macro_enb() ->
     #ext_macro_enb{
-       plmn = plmn(),
+       plmn_id = plmn(),
        id = oneof([uint(18), uint(21)])
       }.
 
@@ -1975,8 +1975,7 @@ gen_v2_charging_characteristics() ->
 gen_v2_trace_information() ->
     #v2_trace_information{
        instance = instance(),
-       mcc = mcc(),
-       mnc = mnc(),
+       plmn_id = plmn(),
        trace_id = uint32(),
        triggering_events = binary(9),
        list_of_ne_types = uint16(),
@@ -2078,8 +2077,7 @@ gen_v2_ue_time_zone() ->
 gen_v2_trace_reference() ->
     #v2_trace_reference{
        instance = instance(),
-       mcc = mcc(),
-       mnc = mnc(),
+       plmn_id = plmn(),
        id = uint24()
       }.
 
@@ -2093,8 +2091,7 @@ gen_v2_complete_request_message() ->
 gen_v2_guti() ->
     #v2_guti{
        instance = instance(),
-       mcc = mcc(),
-       mnc = mnc(),
+       plmn_id = plmn(),
        group_id = uint16(),
        code = uint24(),
        m_tmsi = binary()
@@ -2284,8 +2281,7 @@ gen_v2_rfsp_index() ->
 gen_v2_user_csg_information() ->
     #v2_user_csg_information{
        instance = instance(),
-       mcc = mcc(),
-       mnc = mnc(),
+       plmn_id = plmn(),
        csg_id = bitstring(27),
        access_mode = int_range(0,3),
        lcsg = boolean(),


### PR DESCRIPTION
* use identical records for location and routing information fields on GTP v1 and v2. The content of those fields really is identical (or close to).
* move mcc/mnc fields combination into a plmn_id field

Note: the format of some IE records was changed, a major version will therefore be required for the next release (incompatible API change)