### PR TITLE
fix formatting of generated code

### DIFF
--- a/src/gtp_packet.erl
+++ b/src/gtp_packet.erl
@@ -3381,10 +3381,10 @@ decode_v2_element(<<M_flags/binary>>, 77, Instance) ->
                                'PCRI','AOSI','AOPI','ROAAI','EPCOSI','CPOPCI',
                                'PMTSMI','S11TF','PNSI','UNACCSI','WPMSI',
                                '5GSNN26','REPREFI','5GSIWK','EEVRSI','LTEMUI',
-                               'LTEMPI','ENBCRSI','TSPCMI', 'CSRMFI', 'MTEDTN', 
-                               'MTEDTA', 'N5GNMI', '5GCNRS', '5GCNRI', '5SRHOI', 
-                               'ETHPDN', '_', '_', '_', '_', 'SISSME', 'NSENBI', 
-                               'IPFUPF', 'EMCI'])};
+                               'LTEMPI','ENBCRSI','TSPCMI','CSRMFI','MTEDTN',
+                               'MTEDTA','N5GNMI','5GCNRS','5GCNRI','5SRHOI',
+                               'ETHPDN','_','_','_','_','SISSME','NSENBI',
+                               'IPFUPF','EMCI'])};
 
 decode_v2_element(<<M_config/binary>>, 78, Instance) ->
     #v2_protocol_configuration_options{instance = Instance,
@@ -4179,11 +4179,11 @@ encode_v2_element(#v2_indication{
                                            'CPOPCI','EPCOSI','ROAAI','TSPCMI',
                                            'ENBCRSI','LTEMPI','LTEMUI',
                                            'EEVRSI','5GSIWK','REPREFI',
-                                           '5GSNN26', 'ETHPDN','5SRHOI',
+                                           '5GSNN26','ETHPDN','5SRHOI',
                                            '5GCNRI','5GCNRS','N5GNMI',
-                                           'MTEDTA','MTEDTN', 'CSRMFI', 'EMCI', 
-                                           'IPFUPF', 'NSENBI', 'SISSME', 
-                                           '_', '_', '_', '_']), little))/binary>>);
+                                           'MTEDTA','MTEDTN','CSRMFI','EMCI',
+                                           'IPFUPF','NSENBI','SISSME','_','_',
+                                           '_','_']), little))/binary>>);
 
 encode_v2_element(#v2_protocol_configuration_options{
 		     instance = Instance,


### PR DESCRIPTION
Looks like someone manually edited the code in question. In order to maintain the sync between the code generator and the code it generated, regenerate the part in questions.