### PR TITLE
handle IMEIs shorter than 15 digits

### DIFF
--- a/priv/ie_gen_v1.erl
+++ b/priv/ie_gen_v1.erl
@@ -282,7 +282,7 @@ ies() ->
        {"DST", 2, integer},
        {'_', 0}]},
      {154, "IMEI", '_',
-      [{"IMEI", 64, {type, tbcd}},
+      [{"IMEI", 64, {type, imei}},
        {'_', 0}]},
      {155, "CAMEL Charging Information Container", '_',
       []},

--- a/src/gtp_packet.erl
+++ b/src/gtp_packet.erl
@@ -767,6 +767,13 @@ encode_imsi(IMSI) ->
     << B:64/bits, _/binary>> = << (encode_tbcd(IMSI))/binary, -1:64 >>,
     B.
 
+decode_imei(Bin) ->
+    decode_tbcd(Bin).
+
+encode_imei(IMEI) ->
+    << B:64/bits, _/binary>> = << (encode_tbcd(IMEI))/binary, -1:64 >>,
+    B.
+
 encode_v1_rai(#routeing_area_identity{
                  identity = #rai{plmn_id = {MCC, MNC}, lac = LAC, rac = RAC}}) ->
     <<(encode_mccmnc(MCC, MNC))/binary, LAC:16, (RAC bsr 8):8>>.
@@ -1706,7 +1713,7 @@ decode_v1_element(<<M_timezone:8/integer,
 decode_v1_element(<<M_imei:64/bits,
                     _/binary>>, 154, Instance) ->
     #imei{instance = Instance,
-          imei = decode_tbcd(M_imei)};
+          imei = decode_imei(M_imei)};
 
 decode_v1_element(<<>>, 155, Instance) ->
     #camel_charging_information_container{instance = Instance};
@@ -2462,7 +2469,7 @@ encode_v1_element(#ms_time_zone{
 encode_v1_element(#imei{
                      instance = Instance,
                      imei = M_imei}) ->
-    encode_v1_element(154, Instance, <<(encode_tbcd(M_imei)):64/bits>>);
+    encode_v1_element(154, Instance, <<(encode_imei(M_imei)):64/bits>>);
 
 encode_v1_element(#camel_charging_information_container{
                      instance = Instance}) ->

--- a/test/gtp_SUITE.erl
+++ b/test/gtp_SUITE.erl
@@ -58,6 +58,7 @@ all() ->
      test_v1_ignore_spare_bits,
      test_g_pdu,
      test_v2_pco_vendor_ext,
+     v1_invalid_imei,
      v2_list,
      partial_decode,
      partial_encode,
@@ -281,6 +282,16 @@ test_v2_pco_vendor_ext(_Config) ->
     Msg = v2_pco_vendor_ext(),
     ?match(Data when is_binary(Data), (catch gtp_packet:encode(Msg))),
     ok.
+
+v1_invalid_imei() ->
+    [{doc, "Try to encode an IMEI shorter that 15 digits"}].
+v1_invalid_imei(_Config) ->
+    %% IMEIs are 15 digits and IMEI-SVs are 16 digits, anything else is not a valid
+    %% IMEI. However, somehow 14 digit values are observed in the wild. Make sure that
+    %% encoder/decoder handles them, so that higher levels can deal with the values.
+    Msg = #gtp{version = v1, type = create_pdp_context_request, seq_no = 1, tei = 0,
+               ie = #{{imei, 0} => #imei{imei = <<"1234567890">>}}},
+    ?equal(Msg, gtp_packet:decode(gtp_packet:encode(Msg))).
 
 v2_list(_Config) ->
     IEs =


### PR DESCRIPTION
IMEIs are 15 digits and IMEI-SVs are 16 digits (3GPP TS 23.003, clause 6.2), anything else is not a valid IMEI. However, somehow 14 digit values are observed in the wild. Make sure that encoder/decoder handles them, so that higher levels can deal with the values.